### PR TITLE
Swap to using slim-buster python image

### DIFF
--- a/_episodes/10-singularity-containers.md
+++ b/_episodes/10-singularity-containers.md
@@ -166,38 +166,29 @@ Singularity can also start containers from Docker images, opening up access to a
 
 While Singularity doesn't support running Docker images directly, it can pull them from Docker Hub and convert them into a suitable format for running via Singularity. When you pull a Docker image, Singularity pulls the slices or _layers_ that make up the Docker image and converts them into a single-file Singularity SIF image.
 
-For example, moving on from the simple _Hello World_ examples that we've looked at so far, let's pull one of the [official Docker Python images](https://hub.docker.com/_/python). We'll use the image with the tag `3.8.2-buster` which has Python 3.8.2 installed on Debian's [Buster](https://www.debian.org/releases/buster/) (v10) Linux distribution:
+For example, moving on from the simple _Hello World_ examples that we've looked at so far, let's pull one of the [official Docker Python images](https://hub.docker.com/_/python). We'll use the image with the tag `3.8.2-slim-buster` which has Python 3.8.2 installed on Debian's [Buster](https://www.debian.org/releases/buster/) (v10) Linux distribution:
 
 ~~~
-$ singularity pull python-3.8.2.sif docker://python:3.8.2-buster
+$ singularity pull python-3.8.2.sif docker://python:3.8.2-slim-buster
 ~~~
 {: .language-bash}
 
 ~~~
 INFO:    Converting OCI blobs to SIF format
 INFO:    Starting build...
-Getting image source signatures
-Copying blob f15005b0235f done
-Copying blob 41ebfd3d2fd0 done
-Copying blob b998346ba308 done
-Copying blob f01ec562c947 done
-Copying blob 2447a2c11907 done
-Copying blob fdd2d569da3e done
-Copying blob ac3886b74a9f done
-Copying blob 3c783a9b35dd done
-Copying blob ce16dda809f6 done
-Copying config 983a7273bc done
+Copying blob 54fec2fa59d0 done
+Copying blob cd3f35d84cab done
+Copying blob a0afc8e92ef0 done
+Copying blob 9691f23efdb7 done
+Copying blob 6512e60b314b done
+Copying config 1c498e093b done
 Writing manifest to image destination
 Storing signatures
-2020/04/15 16:52:42  info unpack layer: sha256:f15005b0235fa8bd31cc6988c4f2758016fe412d696e81aecf73e52be079f19e
-2020/04/15 16:52:45  info unpack layer: sha256:41ebfd3d2fd0de99b1c63aa36a507bf5555481d06e571d84ed84440d30671494
-2020/04/15 16:52:45  info unpack layer: sha256:b998346ba308e3362a85c7bf7faed28d0277c68203696134192fe812f809abb2
-2020/04/15 16:52:45  info unpack layer: sha256:f01ec562c947a8ca1b168415da6a4a8f8920808f9b5d6f420ef8fa9af249b1f1
-2020/04/15 16:52:47  info unpack layer: sha256:2447a2c119076510a07d71cfcec029fceac2e59eea21fc7b39cf0eb234d3798e
-2020/04/15 16:52:55  info unpack layer: sha256:fdd2d569da3eb90bae8b2b7b097b369818974f8a4eff48bc06263ea61d44d9f7
-2020/04/15 16:52:55  info unpack layer: sha256:ac3886b74a9ff0d174f2a1e6c27cb492d43b3d2b97a5e0ed4c1ae12a82f584da
-2020/04/15 16:52:56  info unpack layer: sha256:3c783a9b35ddbae49d3ed42c93ab9710f82ee5633caaca6bedd1074ced380e56
-2020/04/15 16:52:56  info unpack layer: sha256:ce16dda809f69733b41448cfc947ab4485da9c1f7481332ad1da436e636891ab
+2020/07/03 11:16:22  info unpack layer: sha256:54fec2fa59d0a0de9cd2dec9850b36c43de451f1fd1c0a5bf8f1cf26a61a5da4
+2020/07/03 11:16:24  info unpack layer: sha256:cd3f35d84caba5a287676eeaea3d371e1ed5af8c57c33532228a456e0505b2d5
+2020/07/03 11:16:24  info unpack layer: sha256:a0afc8e92ef0f5e56ddda03f8af40a4396226443a446e457ab6ed2dcdec62619
+2020/07/03 11:16:25  info unpack layer: sha256:9691f23efdb7fd2829d06ad8fb9c8338487c183bb1aefa0d737cece2a612f51b
+2020/07/03 11:16:25  info unpack layer: sha256:6512e60b314b980bce8ece057d15292db0f50ca12dbe6dd5752e1e54c64ccca2
 INFO:    Creating SIF file...
 INFO:    Build complete: python-3.8.2.sif
 ~~~

--- a/_episodes/10-singularity-containers.md
+++ b/_episodes/10-singularity-containers.md
@@ -214,7 +214,7 @@ We can now run a container from this image as we would with any other singularit
 > > This should put you straight into a Python interactive shell within the running container:
 > > 
 > > ~~~
-> > Python 3.8.2 (default, Mar 31 2020, 15:23:55) 
+> > Python 3.8.2 (default, Apr 23 2020, 14:32:57)
 > > [GCC 8.3.0] on linux
 > > Type "help", "copyright", "credits" or "license" for more information.
 > > >>> 


### PR DESCRIPTION
Slim image is about 1/6th the size. This should save some time for anybody using Singularity on their own machines.